### PR TITLE
adding slurm to plugins in tests

### DIFF
--- a/pydra/engine/tests/test_node_task.py
+++ b/pydra/engine/tests/test_node_task.py
@@ -8,7 +8,10 @@ from .utils import fun_addtwo, fun_addvar, moment, fun_div
 from ..core import TaskBase
 from ..submitter import Submitter
 
-Plugins = ["cf"]
+if bool(shutil.which("sbatch")):
+    Plugins = ["cf", "slurm"]
+else:
+    Plugins = ["cf"]
 
 
 @pytest.fixture(scope="module")

--- a/pydra/engine/tests/test_workflow.py
+++ b/pydra/engine/tests/test_workflow.py
@@ -9,7 +9,10 @@ from ..core import Workflow
 from ... import mark
 
 
-Plugins = ["cf"]
+if bool(shutil.which("sbatch")):
+    Plugins = ["cf", "slurm"]
+else:
+    Plugins = ["cf"]
 
 
 @pytest.mark.parametrize("plugin", Plugins)


### PR DESCRIPTION
## Summary
<!--- What does your code do? -->
I've realized that `slurm` was not added to all of the tests. Not sure what was the reason, but I believe it should be included.

## Checklist
<!--- Please, let us know if you need help-->
- [ ] All tests passing
- [ ] I have added tests to cover my changes
- [ ] I have updated documentation (if necessary)
- [ ] My code follows the code style of this project 
(we are using `black`: you can `pip install pre-commit`, 
run `pre-commit install` in the `pydra` directory 
and `black` will be run automatically with each commit)

## Acknowledgment
- [x] I acknowledge that this contribution will be available under the Apache 2 license.